### PR TITLE
Fix error when a blank url is submitted

### DIFF
--- a/pub/scripts/PageController.js
+++ b/pub/scripts/PageController.js
@@ -398,7 +398,7 @@ PageController.prototype.updatePageState = function () {
 
 PageController.prototype.updatePageTitle = function (pageTitleString) {
   var pageTitle = 'Charted'
-  var charts = [{}]
+  var charts = []
   if (this.parameters && this.parameters.charts) {
     charts = this.parameters.charts
   }


### PR DESCRIPTION
This fixes an error introduced in 00664b9d54d79cde1a24bbb6eb5f2d28679739c3 where submitting a blank url would cause an error on [this line](https://github.com/mikesall/charted/blob/00664b9d54d79cde1a24bbb6eb5f2d28679739c3/pub/scripts/PageController.js#L240).  
