### PR TITLE
Fixes an error with detecting the selected column section

### DIFF
--- a/pub/scripts/Chart.js
+++ b/pub/scripts/Chart.js
@@ -420,7 +420,7 @@ Chart.prototype.getClosestPoint = function(pixel) {
     // determine if position is over a y series stack, else show the total
     var yValueExtent = this.data.getStackedExtentForIndex(currentX)
     var yPixelExtent = [this.yScale(yValueExtent[0]), this.yScale(yValueExtent[1])]
-    if (pixelY < yPixelExtent[1] || pixelY > yPixelExtent[0]) {
+    if (pixelY <= yPixelExtent[1] || pixelY > yPixelExtent[0]) {
       currentY = this.data.getSeriesCount()
     }
   }


### PR DESCRIPTION
This fixes a weird error that occurs on mouseover of the top-most pixel of the last column.

Here's a simple [test case](http://www.charted.co/?%7B%22dataUrl%22%3A%22https%3A%2F%2Fdl.dropboxusercontent.com%2Fu%2F19226291%2Fdata13.csv%22%7D). Mouse over the top of the second column to receive an `Uncaught TypeError` at [this line](https://github.com/mikesall/charted/blob/9b5b79abe34f15e5bf63f4130d0ab3fd26260a1e/pub/scripts/ChartData.js#L53). The issue seems to occur because the mouse is able to be outside of the column, but not inside of the range that's considered "outside of the column".

I'm not sure if this fix is simply a band-aid fix or actually fixes the issue, but it seems to work well. A more in-depth analysis should be given to the `Chart#getClosestPoint` function to determine the root cause of the issue.
