### PR TITLE
Fix forward/back

### DIFF
--- a/pub/scripts/PageController.js
+++ b/pub/scripts/PageController.js
@@ -392,7 +392,11 @@ PageController.prototype.updatePageState = function () {
   // set url
   var minParams = this.getMinParams()
   var url = '?' + encodeURIComponent(JSON.stringify(minParams))
-  window.history.pushState(null, null, url)
+
+  // only push a new state if the new url differs from the current url
+  if (window.location.search !== url) {
+    window.history.pushState(null, null, url)
+  }
 }
 
 
@@ -481,7 +485,13 @@ PageController.prototype.useUrl = function () {
   // support prior csvUrl parameter
   urlParameters.dataUrl = urlParameters.csvUrl || urlParameters.dataUrl
 
-  if (!urlParameters.dataUrl) return
+  // handle the state change from chart -> pre-load
+  if (!urlParameters.dataUrl) {
+    this.clearExisting()
+    this.$body.addClass('pre-load')
+    return
+  }
+
   $('.data-file-input').val(urlParameters.dataUrl)
   this.setupPage(urlParameters)
 }

--- a/pub/scripts/charted.js
+++ b/pub/scripts/charted.js
@@ -15,5 +15,7 @@ $(function () {
     }
   })
 
-  $(window).on('popstate', pageController.useUrl())
+  // parse the url on page load and every state change
+  pageController.useUrl()
+  $(window).on('popstate', pageController.useUrl.bind(pageController))
 })


### PR DESCRIPTION
This resolves issue #10.

On [charted.js line 18](https://github.com/mikesall/charted/blob/45e09315208bbbe9fa537fea4be2ae1c883b63b2/pub/scripts/charted.js#L18), the function was called instead of passing it as a handler to `popstate`. Incidentally, this had the side effect of restoring state on page load, even though it wasn't intended.

Going back then going forward would push two copies of the url onto the history stack, so a check had to made to prevent that.

And finally, there needed to be a check to restore the pre-load state if the user is returning from a chart.
