### PR TITLE
Package Charted as a Node module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Charted
-Charted is a tool for automatically visualizing data, originally created by 
+Charted is a tool for automatically visualizing data, originally created by
 the Product Science team at [Medium](https://medium.com/). Provide the
 link to a data file and Charted returns a beautiful, interactive,
 and shareable chart of the data. The charts look like this:
 
 ![Example Chart Screenshot](img/example_chart_screenshot.png?raw=true "Example Chart Screenshot")
 
-Charted is deliberately sparse in formatting and data transformation options, 
+Charted is deliberately sparse in formatting and data transformation options,
 and instead gives you a few powerful core features:
 * Rendering well on all screen sizes, including monitors
 * Re-fetching the data and updating the chart every 30 minutes
@@ -42,3 +42,17 @@ You can also run Charted via _docker_ by running
 will then be able to run the container using
 `docker run -p 3000:3000 charted`. Server will be accessible at
 localhost:3000
+
+## Using the Node module
+
+Charted also comes as a Node module which can be included in an
+Express or Matador application. This lets you direct the user to
+Charted URLs within the app, which can fetch data from other routes.
+(Note that Charted adds an endpoint which can make GET requests to
+arbitrary URLs from your app.)
+
+Call `charted(app)` to set up Charted in your app. By default, the
+Charted home page and assets will be served from `/charted/`, which
+you can customize the path by providing another path as a second
+argument. For example, providing '/' will cause Charted to be served
+from the root of your app.

--- a/index.js
+++ b/index.js
@@ -1,32 +1,9 @@
 /*jshint node:true */
-
-var request = require('request')
+var charted = require('./lib/charted.js')
 var express = require('express')
 var app = express()
 
-app.get('/get', function (req, res) {
-  if (!req.query.url) {
-    res.status(400).send('Bad Request: no url provided')
-    return
-  }
-
-  request(decodeURIComponent(req.query.url), function (err, resp, body) {
-    if (err) {
-      res.status(400).send('Bad Request: ' + err)
-      return
-    }
-
-    if (resp.statusCode != 200) {
-      res.status(400).send('Bad Request: response status code was not 200')
-      return
-    }
-
-    res.set('Content-Type', 'text/plain')
-    res.status(200).send(body)
-  })
-})
-
-app.use(express.static('pub'))
+charted(app, '/')
 
 var server = app.listen(process.env.PORT || 3000, function () {
   var host = server.address().address

--- a/lib/charted.js
+++ b/lib/charted.js
@@ -1,0 +1,41 @@
+/*jshint node:true, onevar:false, indent:4 */
+
+var url = require('url')
+var path = require('path')
+var request = require('request')
+var serveStatic = require('serve-static')
+
+module.exports = function(app, charted_root) {
+  if (charted_root === undefined) { charted_root = '/charted/' }
+
+  app.use(charted_root + 'get', function (req, res, next) {
+    var get_url = url.parse(req.url, true).query.url
+
+    if (!get_url) {
+      res.statusCode = 400
+      res.end('Bad Request: no url provided')
+      next()
+      return
+    }
+
+    request(decodeURIComponent(get_url), function (err, resp, body) {
+      if (err) {
+        res.statusCode = 400
+        res.end('Bad Request: ' + err)
+
+      } else if (resp.statusCode != 200) {
+        res.statusCode = 400
+        res.end('Bad Request: response status code was not 200')
+
+      } else {
+        res.setHeader('Content-Type', 'text/plain')
+        res.statusCode = 200
+        res.end(body)
+      }
+
+      next()
+    })
+  })
+
+  app.use(charted_root, serveStatic(path.join(__dirname, '..', 'pub')))
+}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "charted",
-  "version": "0.1.1",
-  "description": "A charting library from Medium",
-  "main": "index.js",
+  "name": "chartedjs",
+  "version": "0.2.0",
+  "description": "A charting library originally created by the Product Science team at Medium",
+  "main": "lib/charted.js",
   "scripts": {
+    "postinstall": "lessc less/charted.less pub/charted.css",
     "prestart": "lessc less/charted.less pub/charted.css",
     "start": "node index.js",
-    "test": "jshint index.js && jshint pub/scripts/*.js && echo 'Lint OK'"
+    "test": "jshint index.js && jshint lib/*.js && jshint pub/scripts/*.js && echo 'Lint OK'"
   },
   "repository": {
     "type": "git",
@@ -24,7 +25,8 @@
     "less": "1.7.x",
     "express": "4.10.x",
     "jshint": "2.5.x",
-    "request": "2.47.x"
+    "request": "2.47.x",
+    "serve-static": "~1.7.2"
   },
   "homepage": "http://www.charted.co/"
 }

--- a/pub/index.html
+++ b/pub/index.html
@@ -7,18 +7,18 @@
     <meta http-equiv='Content-type' content='text/html; charset=utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <link rel="stylesheet" href="/charted.css">
+    <link rel="stylesheet" href="charted.css">
     <script src="//use.edgefonts.net/source-sans-pro:n2,n4,n9.js"></script>
-    <script src="/scripts/lib/jquery.js"></script>
-    <script src="/scripts/lib/d3.js"></script>
-    <script src="/scripts/lib/lodash.compat.js"></script>
-    <script src="/scripts/Utils.js"></script>
-    <script src="/scripts/PageData.js"></script>
-    <script src="/scripts/ChartLegend.js"></script>
-    <script src="/scripts/ChartData.js"></script>
-    <script src="/scripts/Chart.js"></script>
-    <script src="/scripts/PageController.js"></script>
-    <script src="/scripts/charted.js"></script>
+    <script src="scripts/lib/jquery.js"></script>
+    <script src="scripts/lib/d3.js"></script>
+    <script src="scripts/lib/lodash.compat.js"></script>
+    <script src="scripts/Utils.js"></script>
+    <script src="scripts/PageData.js"></script>
+    <script src="scripts/ChartLegend.js"></script>
+    <script src="scripts/ChartData.js"></script>
+    <script src="scripts/Chart.js"></script>
+    <script src="scripts/PageController.js"></script>
+    <script src="scripts/charted.js"></script>
   </head>
 
   <body class="pre-load">
@@ -28,7 +28,7 @@
     <form class="load-data-form">
       <input type="text" class="data-file-input" name="dataUrl" placeholder="Paste the link to a .csv file or Google Spreadsheet">
       <button type="submit" class="submit">Go</button>
-      <div class="loading-spinner"><img class="loading-spinner-img" src="/images/spinner.svg"></div>
+      <div class="loading-spinner"><img class="loading-spinner-img" src="images/spinner.svg"></div>
       <div class="error-message"></div>
     </form>
 
@@ -37,7 +37,7 @@
     <footer>
       <a href="https://github.com/mikesall/charted">GitHub</a>
       <a href="https://medium.com/p/2149df6bb0bd">How it works</a>
-      <a href='/?%7B"dataUrl"%3A"https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2F1PSaAXtklG4UyFm2lui5d4k_UNEO1laAMpzMWVh0FMTU%2Fexport%3Fgid%3D0%26format%3Dcsv"%2C"charts"%3A%5B%7B"title"%3A"An%20Example%20Chart"%2C"note"%3A"This%20is%20an%20example%20chart%20visualizing%20some%20fake%20data"%7D%5D%7D'>Try an example</a>
+      <a href='?%7B"dataUrl"%3A"https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2F1PSaAXtklG4UyFm2lui5d4k_UNEO1laAMpzMWVh0FMTU%2Fexport%3Fgid%3D0%26format%3Dcsv"%2C"charts"%3A%5B%7B"title"%3A"An%20Example%20Chart"%2C"note"%3A"This%20is%20an%20example%20chart%20visualizing%20some%20fake%20data"%7D%5D%7D'>Try an example</a>
     </footer>
   </body>
 </html>

--- a/pub/scripts/PageController.js
+++ b/pub/scripts/PageController.js
@@ -534,7 +534,7 @@ PageController.prototype.pageSettingsHTML = function () {
   template += '      <div class="data-url info-input" contenteditable="true"></div>'
   template += '      <button type="submit" class="update-data-url">Save</button>'
   template += '    </div>'
-  template += '    <a href="/" class="page-option-item go-home"><span class="icon icon-back"></span>Charted home</a>'
+  template += '    <a href="." class="page-option-item go-home"><span class="icon icon-back"></span>Charted home</a>'
   template += '  </div>'
   template += '</div>'
   return _.template(template)

--- a/pub/scripts/PageData.js
+++ b/pub/scripts/PageData.js
@@ -9,7 +9,7 @@ function PageData(dataUrl, callback) {
 }
 
 PageData.prototype.fetchData = function () {
-  var url = '/get/?url=' + encodeURIComponent(this.dataUrl)
+  var url = 'get/?url=' + encodeURIComponent(this.dataUrl)
   d3.text(url, function (error, fileString) {
     if (error) {
       return this.callback(error, null)


### PR DESCRIPTION
Changes:

- Charted initializes itself by being called with a Connect/Express/Matador app as an argument
- Charted will extend that app with Charted-related routes, by default at /charted (can be customized)
- Absolute paths have been made relative
- Bump version number to 0.2.0
- Change NPM package name to 'chartedjs' because of namespace conflict

Reviewers: @mikesall, perhaps @valueof 