### PR TITLE
correctly identify empty cells

### DIFF
--- a/pub/scripts/Utils.js
+++ b/pub/scripts/Utils.js
@@ -118,9 +118,11 @@ Utils.getTrimmedExtent = function (array) {
   var lastNonEmptyItem = 0
 
   array.forEach(function (value, i) {
-    if (value === '' && i === firstNonEmptyItem) {
+    var isEmpty = !value || value.toLowerCase() === 'null'
+
+    if (isEmpty && i === firstNonEmptyItem) {
       firstNonEmptyItem = i + 1
-    } else if (value !== '') {
+    } else if (!isEmpty) {
       lastNonEmptyItem = i
     }
   })


### PR DESCRIPTION
cc: @chaosgame

This PR correctly identifies empty cells so that the lines in line charts begin and end with non-null values.