### PR TITLE
Fixed a bug where in Safari we'd run the setup twice

### DIFF
--- a/pub/scripts/Chart.js
+++ b/pub/scripts/Chart.js
@@ -367,16 +367,19 @@ Chart.prototype.bindInteractions = function () {
   }.bind(this))
 
   // handle mouseover
-  this.$container.mousemove(function (e) {
-    this.handleMouseover(e)
-  }.bind(this))
+  this.$container.mousemove(this.handleMouseover.bind(this))
 }
 
 Chart.prototype.handleMouseover = function(pixel) {
   // show the options
   this.$container.addClass('active')
   $('body').addClass('page-active')
-  clearTimeout(this.mouseTimer)
+
+  if (this.mouseTimer) {
+    clearTimeout(this.mouseTimer)
+    this.mouseTimer = null
+  }
+
   this.mouseTimer = setTimeout(function () {
     if (! this.$optionsElem.is(':hover') && ! this.$chartDescription.is(':hover') && ! this.$pageSettings.is(':hover')) {
       this.$container.removeClass('active')

--- a/pub/scripts/PageController.js
+++ b/pub/scripts/PageController.js
@@ -451,7 +451,7 @@ PageController.prototype.updatePageState = function () {
 
   // only push a new state if the new url differs from the current url
   if (window.location.search !== url) {
-    window.history.pushState(null, null, url)
+    window.history.pushState({isChartUpdate: true}, null, url)
   }
 }
 

--- a/pub/scripts/charted.js
+++ b/pub/scripts/charted.js
@@ -17,5 +17,13 @@ $(function () {
 
   // parse the url on page load and every state change
   pageController.useUrl()
-  $(window).on('popstate', pageController.useUrl.bind(pageController))
+
+  $(window).on('popstate', function (ev) {
+    // Safari and some earlier versions of Chrome fire 'popstate' on
+    // page load so here we make sure that it was actually us who
+    // initiated the state change.
+    if (!ev.state.isChartUpdate) {
+      pageController.useUrl()
+    }
+  })
 })


### PR DESCRIPTION
Safari and some earlier versions of Chrome fire the `popstate` event on load which caused setup to be run twice. That led to all kind of weird bugs.