### PR TITLE
Pass request headers along

### DIFF
--- a/lib/charted.js
+++ b/lib/charted.js
@@ -15,7 +15,12 @@ function fetchData(req, res) {
     return
   }
 
-  request(dataUrl, function (err, resp, body) {
+  // Pass the headers from the original request
+  var baseRequest = request.defaults({
+    headers: req.headers
+  })
+
+  baseRequest(dataUrl, function (err, resp, body) {
     if (err) {
       res.statusCode = 400
       res.end('Bad Request: ' + err)


### PR DESCRIPTION
This will pass the headers from the original request, incase if we need the cookies.