### PR TITLE
Do not pass request headers if data source is external service

### DIFF
--- a/lib/charted.js
+++ b/lib/charted.js
@@ -15,10 +15,13 @@ function fetchData(req, res) {
     return
   }
 
+  var defaults = {}
   // Pass the headers from the original request
-  var baseRequest = request.defaults({
-    headers: req.headers
-  })
+  if (url.parse(dataUrl).host === req.headers.host) {
+    defaults['headers'] = req.headers
+  }
+
+  var baseRequest = request.defaults(defaults)
 
   baseRequest(dataUrl, function (err, resp, body) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartedjs",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "A charting library originally created by the Product Science team at Medium",
   "main": "lib/charted.js",
   "scripts": {


### PR DESCRIPTION
Hello @mikesall, @traviscrawford, 

Please review the following commits I made in branch 'satya-headers'.

60641c742db906d9674003307a05eee14b3a3cd6 (2015-11-16 14:19:53 -0800)
Do not pass request headers if data source is external service

R=@mikesall
R=@traviscrawford

MANUAL TESTING=Manually tested