### PR TITLE
Initial work to enable short URLs on Charted

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -59,7 +59,8 @@ function main(args) {
   rm('-r', 'out')
 
   echo('Creating necessary directories')
-  mkdir('-p', 'out/server/shared')
+  mkdir('-p', 'out/server')
+  mkdir('-p', 'out/shared')
   mkdir('-p', 'out/client/scripts')
   mkdir('-p', 'out/client/shared')
   mkdir('-p', 'out/client/lib')
@@ -89,7 +90,7 @@ function main(args) {
   ls('-R', 'src/shared/*.js').forEach((file) => {
     echo(`Compiling ${file}`)
     transpile(file, 'client')
-    transpile(file, 'server')
+    transpile(file, 'server', true)
   })
 }
 
@@ -97,14 +98,14 @@ function less(src, dest) {
   exec(`lessc ${src} ${dest}`)
 }
 
-function transpile(file, type) {
+function transpile(file, type, isShared) {
   let name = file
     .replace('src/client/', 'scripts/')
     .replace('src/server/', '')
     .replace('src/', '')
 
   let code = cat(file)
-  let dest = type == 'client' ? 'out/client' : 'out/server'
+  let dest = type == 'client' ? 'out/client' : isShared ? 'out' : 'out/server'
   let options = {
     filename: name,
     presets: BABEL_PRESETS,

--- a/lib/interfaces/d3.js
+++ b/lib/interfaces/d3.js
@@ -10,13 +10,19 @@ declare class _D3_SVG {
   line(): Object;
 }
 
+declare class _D3_XHR {
+  header(key: string, value: string): _D3_XHR;
+  post(data: string): _D3_XHR;
+}
+
 declare class _D3 {
   tsv: _D3_TSV_CSV;
   csv: _D3_TSV_CSV;
   scale: _D3_SCALE;
   svg: _D3_SVG;
 
-  text(url: string, callback: Function): void;
+  json(url: string, callback: Function): void;
+  xhr(url: string): _D3_XHR;
   range(range: number): Array<number>;
   extent<T>(list: Array<T>, callback: (item: T) => any): Array<T>;
   max<T>(list: Array<T>): T;

--- a/lib/interfaces/node.js
+++ b/lib/interfaces/node.js
@@ -1,22 +1,28 @@
-declare module "request" {
-  declare function defaults(obj: Object): Function;
-}
-
-declare module "serve-static" {
-  declare function exports(url: string): Function;
-}
-
 declare class ExpressServer {
   address(): {address: string, port: string};
 }
 
+declare class ExpressMiddleware {
+}
+
 declare class ExpressApp {
   listen(port: number, cb: Function): ExpressServer;
-  use(url: string, listener: (req: any, res?: any) => void): void;
+  get(url: string, listener: (req: any, res?: any) => void): void;
+  post(url: string, listener: (req: any, res?: any) => void): void;
+  use(middleware: ExpressMiddleware): void;
 }
 
 declare module "express" {
   declare function exports(): ExpressApp;
+  declare function static(path: string): ExpressMiddleware;
+}
+
+declare module "request" {
+  declare function exports(url: string, cb: Function): void
+}
+
+declare module "body-parser" {
+  declare function json(): ExpressMiddleware;
 }
 
 declare function unescape(str: string): string;

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "babel-plugin-transform-flow-strip-types": "6.3.x",
     "connect": "^3.3.5",
     "express": "4.10.x",
+    "body-parser": "1.14.x",
     "less": "1.7.x",
     "request": "2.47.x",
-    "serve-static": "~1.7.2",
     "shelljs": "0.5.x",
     "nodeunit": "0.9.x"
   },

--- a/src/client/Chart.js
+++ b/src/client/Chart.js
@@ -418,7 +418,7 @@ export class Chart {
         var options = OPTIONS[option]
         this.params[option] = this.params[option] === options[0] ? options[1] : options[0]
         this.render()
-        this.pageController.updatePageState()
+        this.pageController.updateURL()
       })
     })
 
@@ -433,7 +433,7 @@ export class Chart {
           this.params[item] = $elem.text()
           this.updateEditablePlaceholder(item)
         }
-        this.pageController.updatePageState()
+        this.pageController.updateURL()
       })
     })
 

--- a/src/client/ChartLegend.js
+++ b/src/client/ChartLegend.js
@@ -61,7 +61,7 @@ export class ChartLegend {
         } else {
           seriesNames[series.seriesIndex] = $legendInput.text()
         }
-        this.controller.updatePageState()
+        this.controller.updateURL()
       })
 
       // open color input
@@ -109,7 +109,7 @@ export class ChartLegend {
           seriesColors[series] = newColorHex
         }
         this.chart.render()
-        this.controller.updatePageState()
+        this.controller.updateURL()
 
       })
     })

--- a/src/client/PageController.js
+++ b/src/client/PageController.js
@@ -33,11 +33,24 @@ export class PageController {
     })
 
     // setup keystrokes
-    $(document).keyup(function(e) {
-      if (e.keyCode == 27) {
+    $(document).keyup((ev) => {
+      if (ev.keyCode == 27) {
         $('.overlay-container').remove()
         $('.page-settings').removeClass('open')
       }
+    })
+
+    $('.load-data-form').submit((ev) => {
+      ev.preventDefault()
+
+      let url = $('.data-file-input').val()
+      if (!url) {
+        let err = 'You’ll need to paste in the URL to a .csv file or Google Spreadsheet first.'
+        this.errorNotify(new Error(err))
+        return
+      }
+
+      pageController.setupPage(new ChartParameters(url))
     })
   }
 

--- a/src/client/PageData.js
+++ b/src/client/PageData.js
@@ -1,11 +1,17 @@
 /* @flow */
 
-import {stringToNumber} from "../shared/utils"
+import * as utils from "../shared/utils"
 
 export default class PageData {
   indices: Array<string>;
   serieses: Array<t_SERIES>;
   data: Array<Array<t_FIELD>>;
+
+  static fromJSON(url: string, data: string) {
+    let ext = utils.getFileExtension(url)
+    let rows = ext == 'tsv' ? d3.tsv.parseRows(data) : d3.csv.parseRows(data)
+    return new PageData(rows)
+  }
 
   constructor(rows: Array<Array<string>>) {
     // Extract field names and build an array of row objects
@@ -36,7 +42,7 @@ export default class PageData {
       return fields.map((row, i) => {
         return {
           x: i,
-          y: stringToNumber(row[label]),
+          y: utils.stringToNumber(row[label]),
           xLabel: this.indices[i],
           yRaw: row[label]
         }

--- a/src/client/charted.js
+++ b/src/client/charted.js
@@ -1,25 +1,9 @@
 /* @flow */
 
 import {PageController} from "./PageController"
-import ChartParameters from "../shared/ChartParameters"
 
 $(function () {
-  var $dataInput = $('.data-file-input')
   var pageController = new PageController()
-
-  $('.load-data-form').submit(function (e) {
-    e.preventDefault()
-
-    if($dataInput.val()) {
-      let params = new ChartParameters($dataInput.val())
-      pageController.setupPage(params)
-    } else {
-      var emptyInputError = new Error('You’ll need to paste in the URL to a .csv file or Google Spreadsheet first.')
-      pageController.errorNotify(emptyInputError)
-    }
-  })
-
-  // parse the url on page load and every state change
   pageController.useUrl()
 
   $(window).on('popstate', function (ev) {

--- a/src/client/charted.js
+++ b/src/client/charted.js
@@ -4,14 +4,5 @@ import {PageController} from "./PageController"
 
 $(function () {
   var pageController = new PageController()
-  pageController.useUrl()
-
-  $(window).on('popstate', function (ev) {
-    // Safari and some earlier versions of Chrome fire 'popstate' on
-    // page load so here we make sure that it was actually us who
-    // initiated the state change.
-    if (ev && ev.state && ev.state.isChartUpdate) {
-      pageController.useUrl()
-    }
-  })
+  pageController.activate()
 })

--- a/src/client/templates.js
+++ b/src/client/templates.js
@@ -36,7 +36,7 @@ function pageSettings(): string {
           </button>
         </div>
 
-        <a href="." class="page-option-item go-home">
+        <a href="/" class="page-option-item">
           <span class="icon icon-back"></span>Charted home
         </a>
       </div>

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -7,13 +7,13 @@
     <meta http-equiv='Content-type' content='text/html; charset=utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <link rel="stylesheet" href="charted.css">
+    <link rel="stylesheet" href="/charted.css">
     <script src="//use.edgefonts.net/source-sans-pro:n2,n4,n9.js"></script>
-    <script src="lib/jquery.js"></script>
-    <script src="lib/d3.js"></script>
-    <script src="lib/lodash.compat.js"></script>
+    <script src="/lib/jquery.js"></script>
+    <script src="/lib/d3.js"></script>
+    <script src="/lib/lodash.compat.js"></script>
 
-    <script async src="lib/require.js" data-main="scripts/charted"></script>
+    <script async src="/lib/require.js" data-main="/scripts/charted"></script>
   </head>
 
   <body class="pre-load">
@@ -21,13 +21,13 @@
     <h2 class="page-subtitle">Beautiful, automatic charts</h2>
 
     <div class="loading-embed-spinner">
-      <img class="loading-spinner-img" src="images/spinner-dark.svg">
+      <img class="loading-spinner-img" src="/images/spinner-dark.svg">
     </div>
 
     <form class="load-data-form">
       <input type="text" class="data-file-input" name="dataUrl" placeholder="Paste the link to a .csv file or Google Spreadsheet">
       <button type="submit" class="submit">Go</button>
-      <div class="loading-spinner"><img class="loading-spinner-img" src="images/spinner.svg"></div>
+      <div class="loading-spinner"><img class="loading-spinner-img" src="/images/spinner.svg"></div>
       <div class="error-message"></div>
     </form>
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,17 +1,9 @@
 /* @flow */
 
-"use strict"
+'use strict'
 
-import charted from "./charted.js"
-import express from "express"
+import path from "path"
+import ChartedServer from './charted'
 
-const app = express()
-
-charted(app, '/')
-
-var server = app.listen(process.env.PORT || 3000, function () {
-  let host = server.address().address
-  let port = server.address().port
-
-  console.log('Running at http://%s:%s', host, port)
-})
+ChartedServer.start(process.env.PORT || 3000, path.join(__dirname, '..', 'client'))
+  .then((address: any) => console.log(`Running at ${address.address}:${address.port}`))


### PR DESCRIPTION
WARNING: This is a backwards incompatible change. It will break
installations (well, one particular installation) which use
Matador instead of Express. It also makes it impossible to use
charted under the path.

Not finished yet:
 * getDefaultTitle on the server-side
 * embeds
 * redis support
 * filesystem support
 * error when save files
 * legacy urls (middleware?)

Refs #71.