### PR TITLE
Support for legacy URLs

### DIFF
--- a/src/client/ChartParameters.js
+++ b/src/client/ChartParameters.js
@@ -46,7 +46,6 @@ export default class ChartParameters {
   }
 
   static fromQueryString(qs: string): ?ChartParameters {
-    // TODO(anton): When implementing redirect, don't forget about data.csvUrl || data.dataUrl
     let urlParams = utils.parseQueryString(qs)
     let data = urlParams.data
     if (!data) {

--- a/src/server/charted.js
+++ b/src/server/charted.js
@@ -86,6 +86,9 @@ export default class ChartedServer {
     }
 
     this.store.set(id, req.body)
+    res.setHeader('Content-Type', 'application/json')
+    res.statusCode = 200
+    res.end(JSON.stringify({status: 'ok'}))
   }
 
   respondWithHTML(res: any, template: string) {


### PR DESCRIPTION
This adds support for legacy Charted URLs where we encode chart parameters into the query string. Charted now parses the query string, saves parameters into the database, and fetches the data.