### PR TITLE
Ms fixes

### DIFF
--- a/src/client/ChartParameters.js
+++ b/src/client/ChartParameters.js
@@ -30,7 +30,7 @@ export default class ChartParameters {
     this.seriesColors = {}
     this.seriesNames = {}
     this._color = COLOR_LIGHT
-    this._grid = GRID_FULL
+    this._grid = GRID_SPLIT
     this._getDefaultTitle = (i) => '' // no-op
   }
 
@@ -115,7 +115,7 @@ export default class ChartParameters {
     }
 
     // Add grid, if applicable.
-    if (!this.isFull()) {
+    if (this.isFull()) {
       params.grid = this._grid
     }
 

--- a/src/client/PageController.js
+++ b/src/client/PageController.js
@@ -84,7 +84,9 @@ export class PageController {
     // then fetch data.
     if (legacyParams) {
       this.params = legacyParams.withDefaultTitle((i) => this.getDefaultTitle(i))
-      this.updateURL(/* withoutServerUpdate */ false, () => this.fetchPageData())
+      let legacyParamsCompressed = this.params.compress()
+      let legacyDataUrl = legacyParamsCompressed.dataUrl || null
+      this.updateURL(/* withoutServerUpdate */ false, () => this.fetchPageData(legacyDataUrl, /* id */ null, legacyParamsCompressed))
     }
   }
 
@@ -309,7 +311,7 @@ export class PageController {
 
   getDefaultTitle(chartIndex: number): string {
     var series = this.params.charts[chartIndex].series
-    if (!series) {
+    if (!series || !this.data) {
       return 'Charted'
     } else if (series.length === 1) {
       return this.getSeriesName(series[0])


### PR DESCRIPTION
This PR makes split screen the default grid style. It also fixes an issue where, for legacy urls, it was not appropriately preparing the dataUrl provided (e.g., formatting Google Spreadsheets links), and it was not preserving formatting styles from those urls.
  
cc @valueof 