### PR TITLE
Charted should return an error when the dataUrl fails to load.

### DIFF
--- a/src/server/charted.js
+++ b/src/server/charted.js
@@ -141,6 +141,11 @@ export default class ChartedServer {
         return
       }
 
+      if (resp.statusCode != 200) {
+        this.badRequest(res, new Error('Received HTTP-' + resp.statusCode + ' status code from ' + params.dataUrl))
+        return
+      }
+
       res.setHeader('Content-Type', 'application/json')
       res.statusCode = 200
       res.end(JSON.stringify({params: params, data: body}))


### PR DESCRIPTION
Hello @mikesall, @traviscrawford, @valueof, 

Please review the following commits I made in branch 'nathan-statusCode'.

272fd0999527813b3669eb531a3ae613929b63e5 (2016-08-26 15:21:52 -0700)
Charted should return an error when the dataUrl fails to load.

This seems to be happening when the server returns a status code 400.

R=@mikesall
R=@traviscrawford
R=@valueof